### PR TITLE
ci: Update subject pattern in PR title validation

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -34,7 +34,7 @@ jobs:
           requireScope: false
           # Configure additional validation for the subject based on a regex.
           # This example ensures the subject starts with an uppercase character.
-          subjectPattern: ^[A-Z].+$
+          subjectPattern: ^[a-zA-Z].+$
           # If `subjectPattern` is configured, you can use this property to override
           # the default error message that is shown when the pattern doesn't match.
           # The variables `subject` and `title` can be used within the message.


### PR DESCRIPTION
The subject pattern in the PR title validation has been updated to allow both uppercase and lowercase characters at the beginning. This change ensures that PR titles starting with lowercase letters are also accepted.