### PR TITLE
feat: Add Docker Image CI Cleanup workflow

### DIFF
--- a/.github/workflows/docker-image-cleanup.yml
+++ b/.github/workflows/docker-image-cleanup.yml
@@ -1,0 +1,29 @@
+name: Docker Image CI Cleanup
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # Run every day at midnight
+
+jobs:
+  cleanup-docker-image:
+    runs-on: ubuntu-latest
+    environment: development
+    name: Cleanup Docker Image
+
+    steps:
+      - name: Get the username lowercase
+        run: echo "USERNAME=$(echo '${{ github.actor }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
+      - name: Get the repository name lowercase
+        run: echo "REPO_NAME=$(echo '${{ github.repository }}' | cut -d'/' -f2 | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
+      - name:
+        uses: snok/container-retention-policy@v3.0.0
+        with:
+          account: ${{ env.USERNAME }} # GitHub username
+          token: ${{ secrets.PAT }} # Personal Access Token
+          image-names: ${{ env.REPO_NAME }} # Name of the image to cleanup
+          image-tags: "*" # Tag of the image to cleanup
+          tag-selection: "both" # Select both tagged and untagged package versions
+          cut-off: 1w # package versions should be older than `1w` (1 week) to be deleted
+          keep-n-most-recent: 5 # keep up to `n` tagged package versions for each of the packages


### PR DESCRIPTION
Add a new workflow file, docker-image-cleanup.yml, to automate the cleanup of Docker images. This workflow runs every day at midnight and uses a container retention policy to delete older versions of the image. It keeps the most recent 5 tagged package versions and deletes any versions older than 1 week.