### PR TITLE
fix(ci): require Node 22+ and approve pnpm build scripts

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -79,7 +79,7 @@ jobs:
     needs: code-quality
     strategy:
       matrix:
-        node-version: [20, 22, 24]
+        node-version: [22, 24]
 
     steps:
       - name: Harden Runner
@@ -111,7 +111,7 @@ jobs:
     needs: test
     strategy:
       matrix:
-        node-version: [20, 22, 24]
+        node-version: [22, 24]
 
     steps:
       - name: Harden Runner

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/iron
+lts/jod

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     ]
   },
   "engines": {
-    "node": ">=20.x"
+    "node": ">=22.13"
   },
   "packageManager": "pnpm@11.1.2"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,3 @@
 allowBuilds:
-  '@scarf/scarf': set this to true or false
-  esbuild: set this to true or false
+  '@scarf/scarf': false
+  esbuild: true


### PR DESCRIPTION
## Why CI is red on every PR and on `main`

Two independent breakages, both living on `main` and inherited by all open PRs:

1. **pnpm 11 + Node 20 are incompatible.** pnpm 11 imports `node:sqlite`, which requires Node ≥ 22.13. The CI test/build matrix included Node 20, so `pnpm install` crashed on the Node-20 leg (`ERR_UNKNOWN_BUILTIN_MODULE: node:sqlite`), and `fail-fast` cancelled the other legs.
2. **Unapproved build scripts.** `pnpm-workspace.yaml` shipped an unfilled `allowBuilds` stub (`'set this to true or false'`). pnpm 11 treats undecided build scripts as a fatal error, so `pnpm install` exited 1, and vitest 4's dependency-status check aborted `pnpm test` on **every** Node version.

## Fix

- Drop Node 20 from the CI matrix (`[22, 24]`); bump `engines.node` to `>=22.13` and `.nvmrc` to `lts/jod` — aligns the supported baseline with the pinned pnpm 11.
- Fill `allowBuilds`: `esbuild: true` (needs its postinstall binary), `@scarf/scarf: false` (telemetry).

## Verified locally (Node 22+)

`biome ci` ✅ · `pnpm test` 16/16 ✅ · `pnpm lint` ✅ · `pnpm build` ✅